### PR TITLE
Handle invalid input in expense tracker

### DIFF
--- a/expense_tracker/README.md
+++ b/expense_tracker/README.md
@@ -10,4 +10,6 @@ python expense_tracker.py list
 python expense_tracker.py summary
 ```
 
+The amount should be provided as a number (do not quote it).
+
 Expenses are stored in `expenses.json` in the same directory.

--- a/expense_tracker/expense_tracker.py
+++ b/expense_tracker/expense_tracker.py
@@ -19,6 +19,17 @@ def save_expenses(expenses):
 
 
 def add_expense(description, amount, category):
+    """Add a new expense entry.
+
+    The amount is converted to ``float``. If conversion fails the user is
+    informed and the entry is not stored.
+    """
+    try:
+        amount = float(amount)
+    except ValueError:
+        print('Invalid amount. Please enter a numeric value.')
+        return
+
     expenses = load_expenses()
     expense = {
         'description': description,
@@ -43,7 +54,7 @@ def summarize_expenses():
     expenses = load_expenses()
     summary = defaultdict(float)
     for exp in expenses:
-        summary[exp['category']] += float(exp['amount'])
+        summary[exp['category']] += exp['amount']
     for category, total in summary.items():
         print(f"{category}: ${total}")
 

--- a/tests/test_expense_tracker.py
+++ b/tests/test_expense_tracker.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+import expense_tracker.expense_tracker as et
+
+
+def test_invalid_amount_rejected(tmp_path, capsys, monkeypatch):
+    data_file = tmp_path / 'expenses.json'
+    monkeypatch.setattr(et, 'DATA_FILE', data_file)
+    et.add_expense('item', 'not-a-number', 'misc')
+    out = capsys.readouterr().out
+    assert 'Invalid amount' in out
+    assert not data_file.exists()


### PR DESCRIPTION
## Summary
- validate and convert amount when adding expenses
- use floats as stored when summarizing expenses
- clarify numeric amount usage in README
- test invalid amount handling

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e1a5d9f848332a38161f31b16487b